### PR TITLE
Add Composer autoloader. See #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Then, add `github-updater.php` to your plugin folder, and `include()` it from wi
 include( dirname( __FILE__ ) . '/github-updater.php' );
 ```
 
+> Note: This `include( ... )` line is not needed if you pull this package in via Composer and use Compsoer's autoloader.
+
 The code fetches [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to determine whether updates are available.
 
 That's it, have fun!

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then, add `github-updater.php` to your plugin folder, and `include()` it from wi
 include( dirname( __FILE__ ) . '/github-updater.php' );
 ```
 
-> Note: This `include( ... )` line is not needed if you pull this package in via Composer and use Compsoer's autoloader.
+> Note: the above line isn't needed if using Composer.
 
 The code fetches [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to determine whether updates are available.
 

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,10 @@
             "name": "Matt Gibbs",
             "homepage": "https://facetwp.com/"
         }
-    ]
+    ],
+    "autoload": {
+        "files": [
+            "github-updater.php"
+        ]
+    }
 }


### PR DESCRIPTION
This adds the Composer autoloader through a `"files"` directive (which is basically an `include`).

The effect depends on how the package is being pulled in:

1. Site-wide Composer stack: Site loads site-wide autoloader, GHU is automatically active.
2. Plugin-local Composer installation: Plugin loads plugin-local autoloader, GHU is automatically active. Can be overridden by 1. as needed.
3. No Composer: Plugin includes file manually, works just as it does now.