### PR TITLE
Remove Composer mention, as it is not correct anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Then, add `github-updater.php` to your plugin folder, and `include()` it from wi
 include( dirname( __FILE__ ) . '/github-updater.php' );
 ```
 
-> Note: the above line isn't needed if using Composer.
-
 The code fetches [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to determine whether updates are available.
 
 That's it, have fun!


### PR DESCRIPTION
As the autoloader was pulled out again, the note about Composer needs to go, as it is wrong.