### PR TITLE
Fix plugin info

### DIFF
--- a/github-updater.php
+++ b/github-updater.php
@@ -47,9 +47,10 @@ if ( ! class_exists( 'GHU_Core' ) ) {
             $plugins = get_plugins();
             foreach ( $plugins as $plugin_file => $info ) {
                 if ( isset( $this->active_plugins[ $plugin_file ] ) && ! empty( $info['GitHub URI'] ) ) {
+                    // TODO check slug for plugin without dir (no clear relation between plugin_file and slug in WP)
                     $temp = array(
                         'plugin'            => $plugin_file,
-                        'slug'              => trim( dirname( $plugin_file ), '/' ),  // TODO check plugin without dir
+                        'slug'              => trim( dirname( $plugin_file ), '/' ),
                         'name'              => $info['Name'],
                         'github_repo'       => $info['GitHub URI'],
                         'description'       => $info['Description'],
@@ -91,9 +92,7 @@ if ( ! class_exists( 'GHU_Core' ) ) {
                             'name'          => $info['name'],
                             'slug'          => $info['slug'],
                             'version'       => $info['new_version'],
-                            'requires'      => '4.7',
-                            'tested'        => get_bloginfo( 'version' ),
-                            'last_updated'  => date( 'Y-m-d' ),
+                            'download_link' => $info['package'],
                             'sections' => array(
                                 'description' => $info['description']
                             )


### PR DESCRIPTION
Here is a fix which is two-folds:

- disambiguate the confusion between plugin_file and the slug. So far i have not found a clear definition of how the plugin slug is obtained in wordpress, but it is used in "plugin_api" when requesting for "plugin_information". It is definitely not the plugin file which is used internally as a key in this code (mistaking the plugin file as the slug). So how to compute the slug? We can assume that in most of the cases the plugin has a directory, in this case the slug seems to be the name of the folder. However there is still a case that must be checked when the plugin is a single file without a dir. Wordpress is very poorly documented here.

- misleading plugin info: i removed the `requires, tested, last_updated` fields that are wrong. I added the download_link to get the button. It is not clear yet how to correctly fill all the fields since you would need to parse the main plugin file from the new version, possibly using wordpress functions.

Still other stuff to be clarified and some hooks can certainly be removed, but this is a starter.